### PR TITLE
v2.0.0 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
Diff: https://github.com/dependabot/updater-action/compare/releases/v1...v2.0.0-release-notes
Draft Release: https://github.com/dependabot/updater-action/releases/tag/untagged-ce47c8be2d939a6c85c9

This release establishes the 2.x major version with our bump to from Node 12 to Node 16.