### PR TITLE
Automatically update dist/ files for Dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -1,0 +1,50 @@
+name: Compile dependabot updates
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  fetch-dependabot-metadata:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.2.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+  build-dependabot-changes:
+    runs-on: ubuntu-latest
+    needs: [fetch-dependabot-metadata]
+    if: ${{ needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Read .nvmrc
+        id: nvm
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Rebuild the dist/ directory
+        run: npm run package
+
+      - name: Check in any change to dist/
+        run: |
+          git add dist/
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "[dependabot skip] Update dist/ with build changes" || exit 0
+          git push


### PR DESCRIPTION
When a Dependabot PR is opened, if the updated dependency is classified as a `production` update let's go ahead and run `npm run package` and check in the results so a human maintainer doesn't need to pull the branch and do it.

This is limited to `production` packages as it's pretty unexpected that any development dependency would modify the build, so it would be better to flag that by leaving the branch in a failing state.