### PR TITLE
v2.0.1 Release Notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",


### PR DESCRIPTION
## What's Changed
* Bump ts-jest from 27.0.7 to 27.1.3 by @dependabot in https://github.com/dependabot/updater-action/pull/65
* Bump @types/node-forge from 0.10.3 to 1.0.0 by @dependabot in https://github.com/dependabot/updater-action/pull/60
* Automatically update dist/ files for Dependabot bumps by @brrygrdn in https://github.com/dependabot/updater-action/pull/83
* Bump @actions/core from 1.5.0 to 1.6.0 by @dependabot in https://github.com/dependabot/updater-action/pull/20
* Bump @octokit/webhooks-types from 4.8.0 to 5.4.0 by @dependabot in https://github.com/dependabot/updater-action/pull/85
* Bump jest from 27.3.1 to 27.5.1 by @dependabot in https://github.com/dependabot/updater-action/pull/86
* Use automatically updated Dockerfiles to set the tag of the updater/proxy used. by @brrygrdn in https://github.com/dependabot/updater-action/pull/84
* Bump actions/setup-node from 1 to 2.5.1 by @dependabot in https://github.com/dependabot/updater-action/pull/90

**Full Changelog**: https://github.com/dependabot/updater-action/compare/v2...v2.0.1