### PR TITLE
Switch to using explicit container SHAs

### DIFF
--- a/__tests__/docker-tags.test.ts
+++ b/__tests__/docker-tags.test.ts
@@ -3,13 +3,13 @@ import {UPDATER_IMAGE_NAME, PROXY_IMAGE_NAME} from '../src/docker-tags'
 describe('Docker tags', () => {
   test('UPDATER_IMAGE_NAME', () => {
     expect(UPDATER_IMAGE_NAME).toMatch(
-      /^docker\.pkg\.github\.com\/dependabot\/dependabot-updater:v1$/
+      /^docker\.pkg\.github\.com\/dependabot\/dependabot-updater@sha256:[a-zA-Z0-9]{64}$/
     )
   })
 
   test('PROXY_IMAGE_NAME', () => {
     expect(PROXY_IMAGE_NAME).toMatch(
-      /^docker\.pkg\.github\.com\/github\/dependabot-update-job-proxy:v1$/
+      /^docker\.pkg\.github\.com\/github\/dependabot-update-job-proxy@sha256:[a-zA-Z0-9]{64}$/
     )
   })
 })

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy:v1","updater":"docker.pkg.github.com/dependabot/dependabot-updater:v1"}');
+module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/github/dependabot-update-job-proxy:v1
+FROM docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/dependabot/dependabot-updater:v1
+FROM docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
-  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy:v1",
-  "updater": "docker.pkg.github.com/dependabot/dependabot-updater:v1"
+  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907",
+  "updater": "docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b"
 }


### PR DESCRIPTION
Extracts the final touch from #72 to move us off the `v1` reference for both containers to using actual SHAs.

The versions I've checked in as part of this commit are deliberately 1 version behind `latest` of both. This is so that two things happen:
- We verify Dependabot generates PRs to update us to the correct version(s)
- We have Dependabot PRs we can use to validate our build Action workflow to compile the `dist/` folder using the SHA automagically ✨ 

This should not merge until https://github.com/dependabot/updater-action/pull/91 has been released as I would like to release the refactor to _enable_ this change ahead of the actual container swap over so its easier to test each in isolation.

This gives us affordance to have the `v2` tag fall back from to `v2.0.1` in the event we encounter any unforeseen problems with a `v2.1.0` release that includes the new mechanism.