### PR TITLE
Build the containers manifest for Dependabot Docker PRs

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -16,6 +16,7 @@ jobs:
     # Map the step output to a job output for subsequent jobs
     outputs:
       dependency-type: ${{ steps.dependabot-metadata.outputs.dependency-type }}
+      package-ecosystem: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
     steps:
       - name: Fetch dependabot metadata
         id: dependabot-metadata
@@ -25,7 +26,8 @@ jobs:
   build-dependabot-changes:
     runs-on: ubuntu-latest
     needs: [fetch-dependabot-metadata]
-    if: ${{ needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' }}
+    # We only need to build the dist/ folder if the PR relates to Docker or a production NPM dependency, otherwise we don't expect changes.
+    if: needs.fetch-dependabot-metadata.output.package-ecosystem == 'docker' || ( needs.fetch-dependabot-metadata.output.package-ecosystem == 'npm_and_yarn' && needs.fetch-dependabot-metadata.outputs.dependency-type == 'direct:production' )
     steps:
       # Check out using a PAT so any pushed changes will trigger checkruns
       - uses: actions/checkout@v2
@@ -44,6 +46,14 @@ jobs:
 
       - name: Install NPM dependencies
         run: npm ci
+
+      # If we're reacting to a Docker PR, we have on extra step to refresh and check in the container manifest,
+      # this **must** happen before rebuilding dist/ so it uses the new version of the manifest
+      - name: Rebuild docker/containers.json
+        if: needs.fetch-dependabot-metadata.output.package-ecosystem == 'docker'
+        run: |
+          npm run update-container-manifest
+          git add docker/containers.json
 
       - name: Rebuild the dist/ directory
         run: npm run package


### PR DESCRIPTION
When Dependabot bumps the version of our Docker containers, we need to add an extra step to our build workflow that refreshes the `docker/containers.json` manifest file that we compile.

This updates the workflow to:
- Become aware of the `package-ecosystem` a Dependabot PR addresses
- Perform the build if the ecosystem is docker -or- the ecosystem is npm *and* it relates to a production dependency
- Insert an extra step before we regenerated the `dist/` folder to prepare and check in the manifest changes