### PR TITLE
Update containers to the latest release SHAs

### DIFF
--- a/__tests__/docker-tags.test.ts
+++ b/__tests__/docker-tags.test.ts
@@ -1,15 +1,20 @@
 import {UPDATER_IMAGE_NAME, PROXY_IMAGE_NAME} from '../src/docker-tags'
+import {getImageName} from '../src/update-containers'
 
 describe('Docker tags', () => {
-  test('UPDATER_IMAGE_NAME', () => {
+  test('UPDATER_IMAGE_NAME uses a pinned version and matches the config Dockerfile', () => {
     expect(UPDATER_IMAGE_NAME).toMatch(
       /^docker\.pkg\.github\.com\/dependabot\/dependabot-updater@sha256:[a-zA-Z0-9]{64}$/
     )
+
+    expect(UPDATER_IMAGE_NAME).toEqual(getImageName('Dockerfile.updater'))
   })
 
-  test('PROXY_IMAGE_NAME', () => {
+  test('PROXY_IMAGE_NAME uses a pinned version and matches the config Dockerfile', () => {
     expect(PROXY_IMAGE_NAME).toMatch(
       /^docker\.pkg\.github\.com\/github\/dependabot-update-job-proxy@sha256:[a-zA-Z0-9]{64}$/
     )
+
+    expect(PROXY_IMAGE_NAME).toEqual(getImageName('Dockerfile.proxy'))
   })
 })

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b"}');
+module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907
+FROM docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b
+FROM docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
-  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:79b4f9cd5cd93062ee3403c71bbc5ca1939b8fc27f88cf705d6604b738b0c907",
-  "updater": "docker.pkg.github.com/dependabot/dependabot-updater@sha256:58e10e8dad0e79c532fe439161857c09da0ce4f8bbabbe216cd87dd35a39573b"
+  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9",
+  "updater": "docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a"
 }

--- a/src/update-containers.ts
+++ b/src/update-containers.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-function getImageName(dockerfileName: string): String {
+export function getImageName(dockerfileName: string): String {
   const dockerfile = fs.readFileSync(
     require.resolve(`../docker/${dockerfileName}`),
     'utf8'


### PR DESCRIPTION
Update the action to use the latest release SHAs for both containers:
https://github.com/dependabot/dependabot-updater/pkgs/container/dependabot-updater%2Fdependabot-updater
https://github.com/github/dependabot-update-job-proxy/pkgs/container/dependabot-update-job-proxy%2Fdependabot-update-job-proxy

This update is being performed manually as I'm currently investigating some issues with the automation around this but I do not want to block testing and preparing v2.1.0 any further.