### PR TITLE
Manually update our containers to the latest versions

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a"}');
+module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:a0883887e3144470e09d02bafd8db38e3ca0e7fa82756aa60ffd72a3e56cccbf"}');
 
 /***/ }),
 

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -5,7 +5,7 @@ require('./sourcemap-register.js');/******/ (() => { // webpackBootstrap
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a"}');
+module.exports = JSON.parse('{"proxy":"docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c","updater":"docker.pkg.github.com/dependabot/dependabot-updater@sha256:a0883887e3144470e09d02bafd8db38e3ca0e7fa82756aa60ffd72a3e56cccbf"}');
 
 /***/ }),
 

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9
+FROM docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c

--- a/docker/Dockerfile.updater
+++ b/docker/Dockerfile.updater
@@ -1,1 +1,1 @@
-FROM docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a
+FROM docker.pkg.github.com/dependabot/dependabot-updater@sha256:a0883887e3144470e09d02bafd8db38e3ca0e7fa82756aa60ffd72a3e56cccbf

--- a/docker/containers.json
+++ b/docker/containers.json
@@ -1,4 +1,4 @@
 {
-  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:208134c602d749400c050b03469dbe6d38af64363492f0f70ea5aba916f32ff9",
-  "updater": "docker.pkg.github.com/dependabot/dependabot-updater@sha256:3d6c07043f4f2baf32047634a00a6581cf1124f12a30dcc859ab128f24333a3a"
+  "proxy": "docker.pkg.github.com/github/dependabot-update-job-proxy@sha256:21ca670ef8ef375e4168be3e1cedfe1a165724314299e147303cbeae57d6ba3c",
+  "updater": "docker.pkg.github.com/dependabot/dependabot-updater@sha256:a0883887e3144470e09d02bafd8db38e3ca0e7fa82756aa60ffd72a3e56cccbf"
 }


### PR DESCRIPTION
https://github.com/github/dependabot-update-job-proxy/pkgs/container/dependabot-update-job-proxy%2Fdependabot-update-job-proxy/16074873?tag=latest
https://github.com/dependabot/dependabot-updater/pkgs/container/dependabot-updater%2Fdependabot-updater/16182948?tag=latest

Our automation is still having some issues with credentials, let's just update these containers manually so we can finalise the 2.1.0 release.