### PR TITLE
V2.1.0 release notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dependabot-updater-action",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-updater-action",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "description": "Runs Dependabot workloads via GitHub Actions.",
   "main": "src/main.ts",

--- a/script/bump-version
+++ b/script/bump-version
@@ -26,3 +26,5 @@ git add package.json package-lock.json
 git commit -m "${new_version}"
 
 echo "Branch prepared for ${new_version}"
+echo "To prepare a release, run:"
+echo "  gh create ${new_version} --draft --generate-notes"


### PR DESCRIPTION
## What's Changed
* Switch to using explicit container SHAs by @brrygrdn in https://github.com/dependabot/updater-action/pull/92
* Build the containers manifest for Dependabot Docker PRs by @brrygrdn in https://github.com/dependabot/updater-action/pull/93
* Update containers to the latest release SHAs by @brrygrdn in https://github.com/dependabot/updater-action/pull/95
* Ensure we wait for container downloads if they don't exist by @brrygrdn in https://github.com/dependabot/updater-action/pull/96
* Fix cleanup of network and containers by @brrygrdn in https://github.com/dependabot/updater-action/pull/97
* Cleanup old image versions by @brrygrdn in https://github.com/dependabot/updater-action/pull/98
* Bump follow-redirects from 1.14.7 to 1.14.9 by @dependabot in https://github.com/dependabot/updater-action/pull/101
* Bump @types/node from 16.4.6 to 17.0.21 by @dependabot in https://github.com/dependabot/updater-action/pull/89
* Bump ansi-regex downstream deps by @brrygrdn in https://github.com/dependabot/updater-action/pull/104
* Bump husky from 7.0.2 to 7.0.4 by @dependabot in https://github.com/dependabot/updater-action/pull/87
* Bump eslint from 7.31.0 to 8.9.0 by @dependabot in https://github.com/dependabot/updater-action/pull/81
* Manually update our containers to the latest versions by @brrygrdn in https://github.com/dependabot/updater-action/pull/109

**Full Changelog**: https://github.com/dependabot/updater-action/compare/v2...v2.1.0